### PR TITLE
fix: Check HTTPS_ENABLED env var before HTTPS redirection

### DIFF
--- a/src/lostcity/routes/about/index.js
+++ b/src/lostcity/routes/about/index.js
@@ -1,18 +1,20 @@
+import Environment from '#lostcity/util/Environment.js';
+
 export default function (f, opts, next) {
     f.get('/', async (req, res) => {
-        return res.view('about/index');
+        return res.view('about/index', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/getstart', async (req, res) => {
-        return res.view('about/getstart');
+        return res.view('about/getstart', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/virtual', async (req, res) => {
-        return res.view('about/virtual');
+        return res.view('about/virtual', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/whatisrs', async (req, res) => {
-        return res.view('about/whatisrs');
+        return res.view('about/whatisrs', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     next();

--- a/src/lostcity/routes/create/index.ts
+++ b/src/lostcity/routes/create/index.ts
@@ -4,6 +4,8 @@ import { toDisplayName, toSafeName } from '#jagex2/jstring/JString.js';
 
 import { db } from '#lostcity/db/query.js';
 
+import Environment from '#lostcity/util/Environment.js';
+
 enum CreateStep {
     USERNAME,
     TERMS,
@@ -37,6 +39,7 @@ export default function (f: any, opts: any, next: any) {
             delete req.session.createUsername;
 
             return res.view('create/username', {
+                HTTPS_ENABLED: Environment.HTTPS_ENABLED,
                 error: createError
             });
         } else if (createStep === CreateStep.TERMS) {

--- a/src/lostcity/routes/create/index.ts
+++ b/src/lostcity/routes/create/index.ts
@@ -44,10 +44,12 @@ export default function (f: any, opts: any, next: any) {
             });
         } else if (createStep === CreateStep.TERMS) {
             return res.view('create/terms', {
+                HTTPS_ENABLED: Environment.HTTPS_ENABLED,
                 username: createUsername
             });
         } else if (createStep === CreateStep.PASSWORD) {
             return res.view('create/password', {
+                HTTPS_ENABLED: Environment.HTTPS_ENABLED,
                 username: createUsername,
                 error: createError
             });
@@ -55,7 +57,7 @@ export default function (f: any, opts: any, next: any) {
             delete req.session.createStep;
             delete req.session.createUsername;
 
-            return res.view('create/finish');
+            return res.view('create/finish', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
         }
     });
 

--- a/src/lostcity/routes/mod/index.ts
+++ b/src/lostcity/routes/mod/index.ts
@@ -1,4 +1,5 @@
 import { db } from '#lostcity/db/query.js';
+import Environment from '#lostcity/util/Environment.js';
 
 export default function (f: any, opts: any, next: any) {
     f.get('/session/:username', async (req: any, res: any) => {
@@ -8,6 +9,7 @@ export default function (f: any, opts: any, next: any) {
             const account = await db.selectFrom('account').where('username', '=', username).selectAll().executeTakeFirstOrThrow();
 
             return res.view('mod/session', {
+                HTTPS_ENABLED: Environment.HTTPS_ENABLED,
                 account,
                 logs: await db.selectFrom('account_session').where('account_id', '=', account.id).orderBy('timestamp desc').limit(100).selectAll().execute()
             });

--- a/src/lostcity/routes/news/index.ts
+++ b/src/lostcity/routes/news/index.ts
@@ -107,6 +107,7 @@ export default function (f: any, opts: any, next: any) {
             const newspost = await db.selectFrom('newspost').where('id', '=', post).selectAll().executeTakeFirst();
             if (newspost) {
                 return res.view('news/create', {
+                    HTTPS_ENABLED: Environment.HTTPS_ENABLED,
                     categories,
                     date: niceDate(newspost.date),
                     post,
@@ -116,6 +117,7 @@ export default function (f: any, opts: any, next: any) {
         }
 
         return res.view('news/create', {
+            HTTPS_ENABLED: Environment.HTTPS_ENABLED,
             categories
         });
     });
@@ -162,6 +164,7 @@ export default function (f: any, opts: any, next: any) {
         const categories = await db.selectFrom('newspost_category').selectAll().execute();
 
         return res.view('news/create', {
+            HTTPS_ENABLED: Environment.HTTPS_ENABLED,
             categories,
             post,
             date: niceDate(new Date()),
@@ -185,6 +188,7 @@ export default function (f: any, opts: any, next: any) {
             const newspost = await db.selectFrom('newspost').where('id', '=', post).selectAll().executeTakeFirst();
             if (newspost) {
                 return res.view('news/create', {
+                    HTTPS_ENABLED: Environment.HTTPS_ENABLED,
                     categories,
                     post,
                     newspost,
@@ -197,6 +201,7 @@ export default function (f: any, opts: any, next: any) {
         }
 
         return res.view('news/create', {
+            HTTPS_ENABLED: Environment.HTTPS_ENABLED,
             categories,
             post,
             date: niceDate(new Date()),

--- a/src/lostcity/routes/news/index.ts
+++ b/src/lostcity/routes/news/index.ts
@@ -58,6 +58,7 @@ export default function (f: any, opts: any, next: any) {
         newsposts = newsposts.limit(17);
 
         return res.view('news/index', {
+            HTTPS_ENABLED: Environment.HTTPS_ENABLED,
             category,
             page,
             more,
@@ -78,6 +79,7 @@ export default function (f: any, opts: any, next: any) {
         const next = await db.selectFrom('newspost').where('id', '>', req.params.id).where('category_id', '=', newspost.category_id).orderBy('id', 'asc').select('id').executeTakeFirst();
 
         return res.view('news/post', {
+            HTTPS_ENABLED: Environment.HTTPS_ENABLED,
             newspost,
             category,
             date: niceDate(newspost.date),

--- a/src/lostcity/routes/player/index.ts
+++ b/src/lostcity/routes/player/index.ts
@@ -1,4 +1,5 @@
 import { db } from '#lostcity/db/query.js';
+import Environment from '#lostcity/util/Environment.js';
 import LoggerEventType from '#lostcity/util/LoggerEventType.js';
 
 export default function (f: any, opts: any, next: any) {
@@ -9,6 +10,7 @@ export default function (f: any, opts: any, next: any) {
             const account = await db.selectFrom('account').where('username', '=', username).selectAll().executeTakeFirstOrThrow();
 
             return res.view('player/adventurelog', {
+                HTTPS_ENABLED: Environment.HTTPS_ENABLED,
                 account,
                 logs: await db.selectFrom('account_session').where('account_id', '=', account.id).where('event_type', '=', LoggerEventType.ADVENTURE).orderBy('timestamp desc').limit(100).selectAll().execute()
             });

--- a/src/lostcity/routes/website.js
+++ b/src/lostcity/routes/website.js
@@ -6,14 +6,11 @@ import Environment from '#lostcity/util/Environment.js';
 
 export default function (f, opts, next) {
     f.get('/', async (req, res) => {
-        // Convert env variable to boolean
-        const HTTPS_ENABLED = process.env.HTTPS_ENABLED === 'true';
-        // Pass for header.ejs to determine https redirection 
-        return res.view('index', {HTTPS_ENABLED: HTTPS_ENABLED});
+        return res.view('index', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/disclaimer', async (req, res) => {
-        return res.view('disclaimer');
+        return res.view('disclaimer', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/title', async (req, res) => {
@@ -24,6 +21,7 @@ export default function (f, opts, next) {
 
         const latestNews = Environment.DB_HOST ? await db.selectFrom('newspost').orderBy('id', 'desc').limit(5).selectAll().execute() : [];
         return res.view('title', {
+            HTTPS_ENABLED: Environment.HTTPS_ENABLED,
             playerCount,
             newsposts: latestNews
         });
@@ -62,6 +60,7 @@ export default function (f, opts, next) {
         }
 
         return res.view('serverlist', {
+            HTTPS_ENABLED: Environment.HTTPS_ENABLED,
             detail: typeof req.query['hires.x'] !== 'undefined' ? 'high' : 'low',
             method: req.query.method,
             worlds: WorldList,
@@ -93,7 +92,7 @@ export default function (f, opts, next) {
     });
 
     f.get('/privacy', async (req, res) => {
-        return res.view('privacy');
+        return res.view('privacy', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/support', async (req, res) => {
@@ -101,11 +100,11 @@ export default function (f, opts, next) {
     });
 
     f.get('/terms', async (req, res) => {
-        return res.view('terms');
+        return res.view('terms', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/whychoosers', async (req, res) => {
-        return res.view('whychoosers');
+        return res.view('whychoosers', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/worldmap', async (req, res) => {

--- a/src/lostcity/routes/website.js
+++ b/src/lostcity/routes/website.js
@@ -84,7 +84,7 @@ export default function (f, opts, next) {
     });
 
     f.get('/detail', async (req, res) => {
-        return res.view('detail');
+        return res.view('detail', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/manual', async (req, res) => {
@@ -112,7 +112,7 @@ export default function (f, opts, next) {
     });
 
     f.get('/downloads', async (req, res) => {
-        return res.view('downloads');
+        return res.view('downloads', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     next();

--- a/src/lostcity/routes/website.js
+++ b/src/lostcity/routes/website.js
@@ -6,7 +6,10 @@ import Environment from '#lostcity/util/Environment.js';
 
 export default function (f, opts, next) {
     f.get('/', async (req, res) => {
-        return res.view('index');
+        // Convert env variable to boolean
+        const HTTPS_ENABLED = process.env.HTTPS_ENABLED === 'true';
+        // Pass for header.ejs to determine https redirection 
+        return res.view('index', {HTTPS_ENABLED: HTTPS_ENABLED});
     });
 
     f.get('/disclaimer', async (req, res) => {

--- a/src/lostcity/routes/website.js
+++ b/src/lostcity/routes/website.js
@@ -76,7 +76,7 @@ export default function (f, opts, next) {
     });
 
     f.get('/cookies', async (req, res) => {
-        return res.view('cookies');
+        return res.view('cookies', {HTTPS_ENABLED: Environment.HTTPS_ENABLED});
     });
 
     f.get('/copyright', async (req, res) => {

--- a/src/lostcity/util/dockerWorldsConf.js
+++ b/src/lostcity/util/dockerWorldsConf.js
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+
+const worldConfig = [
+    {
+        id: 10,
+        region: process.env.REGION || 'Docker build test',
+        address: `http://localhost:${process.env.WEB_PORT || 3000}`,
+        members: process.env.MEMBERS_WORLD === 'true',
+        portOffset: 0
+    }
+];
+
+const filePath = path.resolve('/usr/src/app/data/config/worlds.json');
+
+fs.mkdirSync(path.dirname(filePath), { recursive: true });
+fs.writeFileSync(filePath, JSON.stringify(worldConfig, null, 2));
+
+console.log('[INFO] Worlds config generated! Much wow ');
+console.log(`
+    (\\(\\ 
+    ( -.-) ☆彡
+    o_(")(")   You're a star!`
+);

--- a/src/lostcity/util/dockerWorldsConf.js
+++ b/src/lostcity/util/dockerWorldsConf.js
@@ -1,3 +1,17 @@
+/**
+ * @fileoverview
+ * This script dynamically loads a world configuration file from the Server repo.
+ * 
+ * Purpose:
+ * - This script loads worlds file dynamically from server repo
+ * - Its meant to be used only with docker production build
+ * 
+ * Why? 
+ * - You don't have to pull and modify Website repository just to configure your worlds
+ * - Simplifies running prod setup
+ * - Keeps the Server repo as the single source 
+*/
+
 import fs from 'fs';
 import path from 'path';
 import worldConfig from '/usr/src/prodWorldsConf.js';

--- a/src/lostcity/util/dockerWorldsConf.js
+++ b/src/lostcity/util/dockerWorldsConf.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import worldConfig from '/usr/src/app/prodWorldsConfig.js';
+import worldConfig from '/usr/src/prodWorldsConfig.js';
 
 const filePath = path.resolve('/usr/src/app/data/config/worlds.json');
 

--- a/src/lostcity/util/dockerWorldsConf.js
+++ b/src/lostcity/util/dockerWorldsConf.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import worldConfig from '/usr/src/prodWorldsConfig.js';
+import worldConfig from '/usr/src/prodWorldsConf.js';
 
 const filePath = path.resolve('/usr/src/app/data/config/worlds.json');
 

--- a/src/lostcity/util/dockerWorldsConf.js
+++ b/src/lostcity/util/dockerWorldsConf.js
@@ -1,24 +1,15 @@
 import fs from 'fs';
 import path from 'path';
-
-const worldConfig = [
-    {
-        id: 10,
-        region: process.env.REGION || 'Docker build test',
-        address: `http://localhost:${process.env.WEB_PORT || 3000}`,
-        members: process.env.MEMBERS_WORLD === 'true',
-        portOffset: 0
-    }
-];
+import worldConfig from '/usr/src/app/prodWorldsConfig.js';
 
 const filePath = path.resolve('/usr/src/app/data/config/worlds.json');
 
-fs.mkdirSync(path.dirname(filePath), { recursive: true });
+fs.mkdirSync(path.dirname(filePath), {recursive: true});
 fs.writeFileSync(filePath, JSON.stringify(worldConfig, null, 2));
 
 console.log('[INFO] Worlds config generated! Much wow ');
 console.log(`
     (\\(\\ 
     ( -.-) ☆彡
-    o_(")(")   You're a star!`
+    o_(")(")   You're a star!\n`
 );

--- a/view/_partial/header.ejs
+++ b/view/_partial/header.ejs
@@ -38,7 +38,17 @@
 <body bgcolor=black text="white" link=#90c040 alink=#90c040 vlink=#90c040 topmargin=0 leftmargin=0>
     <% // https://stackoverflow.com/a/4723302 %>
     <% // https://stackoverflow.com/a/6222280 %>
-    <img style="display: none;" src="https://2004scape.org/img/blank.gif" onload="if (location.protocol !== 'https:') { location.replace(`https:${location.href.substring(location.protocol.length)}`); }">
+    <% if (HTTPS_ENABLED) { %>
+        <img 
+            style="display: none;" 
+            src="https://2004scape.org/img/blank.gif" 
+            onload="if (location.protocol !== 'https:') { location.replace(`https:${location.href.substring(location.protocol.length)}`); }"
+        >
+    <% } else { %>
+        <img 
+            style="display: none;" 
+            src="https://2004scape.org/img/blank.gif">
+    <% } %>
     <table width=100% height=100% cellpadding=0 cellspacing=0>
         <tr>
             <td valign=middle>

--- a/view/_partial/header.ejs
+++ b/view/_partial/header.ejs
@@ -44,10 +44,6 @@
             src="https://2004scape.org/img/blank.gif" 
             onload="if (location.protocol !== 'https:') { location.replace(`https:${location.href.substring(location.protocol.length)}`); }"
         >
-    <% } else { %>
-        <img 
-            style="display: none;" 
-            src="https://2004scape.org/img/blank.gif">
     <% } %>
     <table width=100% height=100% cellpadding=0 cellspacing=0>
         <tr>


### PR DESCRIPTION
### Description
- Uses HTTPS_ENABLED environment var for HTTPS redirection 
- Adds world config loader for docker 
- Users can now configure worlds directly from server repo, when running prod build 

- Environment variable is now passed to all 23 routes which use the header.ejs:

<details>
<summary>ᴄʟɪᴄᴋ ғᴏʀ ᴅᴇᴛᴀɪʟs</summary>

```
whychoosers.ejs
title.ejs
terms.ejs
serverlist.ejs
privacy.ejs
player\adventurelog.ejs
news\post.ejs
news\index.ejs
mod\session.ejs
news\create.ejs
index.ejs
downloads.ejs
create\username.ejs
disclaimer.ejs
detail.ejs
create\terms.ejs
create\password.ejs
create\finish.ejs
cookies.ejs
about\whatisrs.ejs
about\virtual.ejs
about\index.ejs
about\getstart.ejs
```
</details>

<br>

###  Why
For production build to work, these changes need to be made in the Website repository, as docker is pulling it from Server, see [#1074](https://github.com/2004Scape/Server/pull/1074)


