### PR TITLE
feat: Add individual player hiscores

### DIFF
--- a/src/lostcity/routes/hiscores/index.ts
+++ b/src/lostcity/routes/hiscores/index.ts
@@ -140,9 +140,17 @@ export default function (f: any, opts: any, next: any) {
                 ...columnsToSelect,
                 'h.rank',
             ])
-            .where('account.username', '=', username);
+            .where('account.username', '=', username)
+            .orderBy('type', 'asc');
 
-        const results = await combinedQuery.orderBy('type').execute();
+            const results: {
+                account_id: number,
+                type: number,
+                level: number,
+                value: number | bigint,
+                date: string,
+                rank?: number
+            }[] = await combinedQuery.execute();
 
         if (results.length === 0) {
             return res.view('hiscores/no_results', {

--- a/src/lostcity/routes/hiscores/index.ts
+++ b/src/lostcity/routes/hiscores/index.ts
@@ -143,6 +143,14 @@ export default function (f: any, opts: any, next: any) {
             .where('account.username', '=', username);
 
         const results = await combinedQuery.orderBy('type').execute();
+
+        if (results.length === 0) {
+            return res.view('hiscores/no_results', {
+                HTTPS_ENABLED: Environment.HTTPS_ENABLED,
+                toDisplayName,
+                username
+            })
+        }
         
         return res.view('hiscores/player', {
             HTTPS_ENABLED: Environment.HTTPS_ENABLED,

--- a/src/lostcity/routes/hiscores/index.ts
+++ b/src/lostcity/routes/hiscores/index.ts
@@ -114,7 +114,7 @@ export default function (f: any, opts: any, next: any) {
     });
 
     f.get('/player/:username', async (req: any, res: any) => {
-        const { username } = req.params;
+        const username = req.params.username || req.query.username;
 
         const columnsToSelect = ['account_id','h.type','h.level','h.value','h.date'] as const;
 

--- a/src/lostcity/routes/hiscores/index.ts
+++ b/src/lostcity/routes/hiscores/index.ts
@@ -113,5 +113,46 @@ export default function (f: any, opts: any, next: any) {
         });
     });
 
+    f.get('/player/:username', async (req: any, res: any) => {
+        const { username } = req.params;
+
+        const columnsToSelect = ['account_id','h.type','h.level','h.value','h.date'] as const;
+
+        const hiscoreRankQuery = db.selectFrom('hiscore as h')
+            .select([...columnsToSelect])
+            .select((eb) =>
+                eb.fn.agg<number>('row_number', [])
+                    .over((ob) => ob.partitionBy('type').orderBy('value', 'desc').orderBy('date', 'asc'))
+                    .as('rank')
+            );
+
+        const hiscoreLargeRankQuery = db.selectFrom('hiscore_large as h')
+            .select([...columnsToSelect])
+            .select((eb) =>
+                eb.fn.agg<number>('row_number', [])
+                    .over((ob) => ob.partitionBy('type').orderBy('level', 'desc').orderBy('date', 'asc'))
+                    .as('rank')
+            );
+
+        const combinedQuery = db.selectFrom(hiscoreRankQuery.unionAll(hiscoreLargeRankQuery).as('h'))
+            .innerJoin('account', 'account.id', 'h.account_id')
+            .select([
+                ...columnsToSelect,
+                'h.rank',
+            ])
+            .where('account.username', '=', username);
+
+        const results = await combinedQuery.orderBy('type').execute();
+        
+        return res.view('hiscores/player', {
+            HTTPS_ENABLED: Environment.HTTPS_ENABLED,
+            toDisplayName,
+            numberWithCommas,
+            username,
+            categories,
+            results
+        });
+    });
+
     next();
 }

--- a/src/lostcity/routes/hiscores/index.ts
+++ b/src/lostcity/routes/hiscores/index.ts
@@ -143,14 +143,14 @@ export default function (f: any, opts: any, next: any) {
             .where('account.username', '=', username)
             .orderBy('type', 'asc');
 
-            const results: {
-                account_id: number,
-                type: number,
-                level: number,
-                value: number | bigint,
-                date: string,
-                rank?: number
-            }[] = await combinedQuery.execute();
+        const results: {
+            account_id: number,
+            type: number,
+            level: number,
+            value: number | bigint,
+            date: string,
+            rank?: number
+        }[] = await combinedQuery.execute();
 
         if (results.length === 0) {
             return res.view('hiscores/no_results', {

--- a/view/hiscores/index.ejs
+++ b/view/hiscores/index.ejs
@@ -54,9 +54,15 @@
                                         <b>Name</b><br>
                                         <% for (const row of results) { %>
                                             <% if (row.highlighted) { %>
-                                            <font color=yellow><%= toDisplayName(row.username) %></font><br>
+                                            <font color=yellow>
+                                                <a href='/hiscores/player/<%= row.username %>' class=c>
+                                                    <%= toDisplayName(row.username) %>
+                                                </a>
+                                            </font><br>
                                             <% } else { %>
-                                            <%= toDisplayName(row.username) %><br>
+                                            <a href='/hiscores/player/<%= row.username %>' class=c>
+                                                <%= toDisplayName(row.username) %>
+                                            </a><br>
                                             <% } %>
                                         <% } %>
                                         <% for (let i = 0; i < 21 - results.length; i++) { %>

--- a/view/hiscores/index.ejs
+++ b/view/hiscores/index.ejs
@@ -121,14 +121,15 @@
             </table>
         </td>
 
-        <!-- <td>&nbsp&nbsp&nbsp</td>
+        <td>&nbsp&nbsp&nbsp</td>
 
         <td>
             <table width=200 bgcolor=black cellpadding=4>
                 <tr>
                     <td class=b bgcolor=#474747 background=/img/stoneback.gif>
                         <center>
-                            <form action="/hiscores"><b>Search by name</b><br>
+                            <form action="/hiscores/player/">
+                                <b>Search by name</b><br>
                                 <input type=text maxlength=12 size=12 name=username value=""><br>
                                 <input type=submit value='Search' style="margin-top: 4px">
                             </form>
@@ -136,7 +137,7 @@
                     </td>
                 </tr>
             </table>
-        </td> -->
+        </td>
     </tr>
 </table>
 

--- a/view/hiscores/no_results.ejs
+++ b/view/hiscores/no_results.ejs
@@ -1,0 +1,17 @@
+<%- include('../_partial/header.ejs', { title: 'Hiscores' }); %>
+<%- include('../_components/frame-top.ejs'); %>
+<%- include('../_components/content-start.ejs'); %>
+<%- include('../_components/title-box.ejs', { title: '2004Scape Hiscores', links: [{ text: 'All Hiscores', href: '/hiscores' }] }); %>
+
+<table bgcolor="black" cellpadding="4" border="0">
+    <tbody>
+        <tr>
+            <td class="e">
+                <center>No player <span style="color:yellow"><%= toDisplayName(username) %></span> found</center>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<%- include('../_components/content-end.ejs'); %>
+<%- include('../_partial/footer.ejs'); %>

--- a/view/hiscores/player.ejs
+++ b/view/hiscores/player.ejs
@@ -1,0 +1,50 @@
+<%- include('../_partial/header.ejs', { title: 'Hiscores' }); %>
+<%- include('../_components/frame-top.ejs'); %>
+<%- include('../_components/content-start.ejs'); %>
+<%- include('../_components/title-box.ejs', { title: '2004Scape Hiscores', links: [{ text: 'All Hiscores', href: '/hiscores' }] }); %>
+
+<table bgcolor="black" cellpadding="4" border="0">
+    <tbody>
+        <tr>
+            <td class="e">
+                <center>2004Scape Hiscores for <span style="color:yellow"><%= toDisplayName(username) %></span></center>
+                <p>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td colspan="3" width="120"><b>Skill</b></td>
+                                <td width="80" align="right"><b>Rank</b></td>
+                                <td width="80" align="right"><b>Level</b></td>
+                                <td width="80" align="right"><b>XP</b></td>
+                            </tr>
+                            <% for (const row of results) { %>
+                                <tr>
+                                    <td></td>
+                                    <td>&nbsp;</td>
+                                    <td>
+                                        <a href='/hiscores?username=<%= username.toLowerCase() %>&category=<%= row.type %>' class="c">
+                                            <%= categories.find(c => c.id == row.type).name %>
+                                        </a>
+                                    </td>
+                                    <td align="right">
+                                        <%= numberWithCommas(row.rank) %>
+                                    </td>
+                                    <td align="right">
+                                        <%= numberWithCommas(row.level) %>
+                                    </td>
+                                    <td align="right">
+                                        <%= numberWithCommas(row.value) %>
+                                    </td>
+                                </tr>
+                            <% } %>
+                        </tbody>
+                    </table>
+                    <br>
+                </p>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<%- include('../_components/content-end.ejs'); %>
+<%- include('../_partial/footer.ejs'); %>


### PR DESCRIPTION
-  Adds route `/hiscores/player/:username` and `/hiscores/player/?username=?`
- Handles no player found
- Adds search by username on hiscores index
- Links username to player route on hiscores index

### Note:
I could not find a source for the no results view, so it might not be era accurate.

### Incomplete:
- Highlighting and navigating to player's rank on index when clicking a category on the player page. The URL is correct, but the index route needs to handle the username query parameter.