### PR TITLE
feat(hiscores): Add proper username searching, profile selection, small refactors

### DIFF
--- a/src/routes/hiscores/index.ts
+++ b/src/routes/hiscores/index.ts
@@ -56,12 +56,23 @@ function numberWithCommas(x: number) {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
+function resolveSelectedProfile(req: any): { id: string } {
+    let profile = profiles.find((p) => p.id === req.query.profile);
+  
+    if (!profile && req.session.selectedProfile) {
+        profile = profiles.find((p) => p.id === req.session.selectedProfile);
+    }
+    if (!profile) {
+        profile = profiles[0];
+    }
+    req.session.selectedProfile = profile.id;
+  
+    return profile;
+}
+
 export default function (f: any, opts: any, next: any) {
     f.get('/', async (req: any, res: any) => {
-        let profile = profiles.find(p => p.id == req.query.profile);
-        if (typeof profile === 'undefined') {
-            profile = profiles[0];
-        }
+        const profile = resolveSelectedProfile(req);
 
         let category = categories.find(c => c.id == req.query.category);
         if (typeof category === 'undefined') {
@@ -130,6 +141,7 @@ export default function (f: any, opts: any, next: any) {
             toDisplayName,
             numberWithCommas,
             profile,
+            profiles,
             categories,
             category,
             results
@@ -137,10 +149,7 @@ export default function (f: any, opts: any, next: any) {
     });
 
     f.get('/player/:username', async (req: any, res: any) => {
-        let profile = profiles.find(p => p.id == req.query.profile);
-        if (typeof profile === 'undefined') {
-            profile = profiles[0];
-        }
+        const profile = resolveSelectedProfile(req);
 
         const username = req.params.username || req.query.username;
 
@@ -184,6 +193,7 @@ export default function (f: any, opts: any, next: any) {
             return res.view('hiscores/no_results', {
                 toDisplayName,
                 profile,
+                profiles,
                 username
             })
         }
@@ -192,6 +202,7 @@ export default function (f: any, opts: any, next: any) {
             toDisplayName,
             numberWithCommas,
             profile,
+            profiles,
             username,
             categories,
             results

--- a/src/routes/hiscores/index.ts
+++ b/src/routes/hiscores/index.ts
@@ -89,9 +89,11 @@ export default function (f: any, opts: any, next: any) {
 
         query = query.limit(21);
 
-        if (req.query.rank && parseInt(req.query.rank) > 0) {
+        let selectedRank: number = req.query.rank ? parseInt(req.query.rank) : 0;
+
+        if (selectedRank > 0) {
             // note: RS has their rank search place the rank at the bottom of the list
-            query = query.offset(Math.max(parseInt(req.query.rank) - 21, 0));
+            query = query.offset(Math.max(selectedRank - 21, 0));
         }
 
         const results: {
@@ -104,9 +106,8 @@ export default function (f: any, opts: any, next: any) {
             highlighted?: boolean
         }[] = await query.execute();
 
-        if (req.query.rank && parseInt(req.query.rank) > 0) {
-            const rank = parseInt(req.query.rank);
-            const row = results.find(r => r.rank == rank);
+        if (selectedRank > 0) {
+            const row = results.find(r => r.rank == selectedRank);
             if (row) {
                 row.highlighted = true;
             }

--- a/src/routes/hiscores/index.ts
+++ b/src/routes/hiscores/index.ts
@@ -106,13 +106,11 @@ export default function (f: any, opts: any, next: any) {
 
         return res.view('hiscores/index', {
             toDisplayName,
-            getLevelByExp,
             numberWithCommas,
             profile,
             categories,
             category,
-            results,
-            rank: req.query.rank
+            results
         });
     });
 

--- a/src/routes/hiscores/index.ts
+++ b/src/routes/hiscores/index.ts
@@ -144,7 +144,9 @@ export default function (f: any, opts: any, next: any) {
             profiles,
             categories,
             category,
-            results
+            results,
+            rank: req.query.rank,
+            username: req.query.username
         });
     });
 

--- a/src/routes/hiscores/index.ts
+++ b/src/routes/hiscores/index.ts
@@ -71,21 +71,12 @@ export default function (f: any, opts: any, next: any) {
         let query = db.selectFrom(category.large ? 'hiscore_large' : 'hiscore')
             .innerJoin('account', 'account.id', category.large ? 'hiscore_large.account_id' : 'hiscore.account_id')
             .select(['account_id', 'type', 'level', 'value', 'date', 'account.username'])
-            .where('type', '=', category.id).where('profile', '=', profile.id);
-
-        if (category.level) {
-            query = query.orderBy('level', 'desc').orderBy('date', 'asc').select((eb) =>
+            .where('type', '=', category.id).where('profile', '=', profile.id)
+            .orderBy(category.level ? 'level' : 'value', 'desc').orderBy('date', 'asc').select((eb) =>
                 eb.fn.agg<number>('row_number', [])
-                    .over((ob) => ob.partitionBy('type').orderBy('level', 'desc').orderBy('date', 'asc'))
+                    .over((ob) => ob.partitionBy('type').orderBy(category.level ? 'level' : 'value', 'desc').orderBy('date', 'asc'))
                     .as('rank')
             );
-        } else {
-            query = query.orderBy('value', 'desc').orderBy('date', 'asc').select((eb) =>
-                eb.fn.agg<number>('row_number', [])
-                    .over((ob) => ob.partitionBy('type').orderBy('value', 'desc').orderBy('date', 'asc'))
-                    .as('rank')
-            );
-        }
 
         query = query.limit(21);
 

--- a/view/hiscores/index.ejs
+++ b/view/hiscores/index.ejs
@@ -108,6 +108,6 @@
     </tr>
 </table>
 
-<%- include('./partials/search.ejs', { category }) %>
+<%- include('./partials/search.ejs', { category, rank, username }) %>
 <%- include('../_components/content-end.ejs'); %>
 <%- include('../_partial/footer.ejs'); %>

--- a/view/hiscores/index.ejs
+++ b/view/hiscores/index.ejs
@@ -107,45 +107,6 @@
     </tr>
 </table>
 
-<br>
-
-<table>
-    <tr>
-        <td>
-            <table width=200 bgcolor=black cellpadding=4>
-                <tr>
-                    <td class=b bgcolor=#474747 background=/img/stoneback.gif>
-                        <center>
-                            <form action="/hiscores"><b>Search by rank</b><br>
-                                <input type=number maxlength=12 size=12 name=rank value=""><br>
-                                <input type=hidden name=category value='<%= category.id %>'>
-                                <input type=submit value='Search' style="margin-top: 4px">
-                            </form>
-                        </center>
-                    </td>
-                </tr>
-            </table>
-        </td>
-
-        <td>&nbsp&nbsp&nbsp</td>
-
-        <td>
-            <table width=200 bgcolor=black cellpadding=4>
-                <tr>
-                    <td class=b bgcolor=#474747 background=/img/stoneback.gif>
-                        <center>
-                            <form action="/hiscores/player/">
-                                <b>Search by name</b><br>
-                                <input type=text maxlength=12 size=12 name=username value=""><br>
-                                <input type=submit value='Search' style="margin-top: 4px">
-                            </form>
-                        </center>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
-
+<%- include('./partials/search.ejs', { category }) %>
 <%- include('../_components/content-end.ejs'); %>
 <%- include('../_partial/footer.ejs'); %>

--- a/view/hiscores/index.ejs
+++ b/view/hiscores/index.ejs
@@ -2,6 +2,7 @@
 <%- include('../_components/frame-top.ejs'); %>
 <%- include('../_components/content-start.ejs'); %>
 <%- include('../_components/title-box.ejs', { title: '2004Scape ' + profile.name + ' Hiscores' }); %>
+<%- include('./partials/profile.ejs', { profile, profiles }) %>
 
 <table>
     <tr>

--- a/view/hiscores/no_results.ejs
+++ b/view/hiscores/no_results.ejs
@@ -13,5 +13,6 @@
     </tbody>
 </table>
 
+<%- include('./partials/search.ejs') %>
 <%- include('../_components/content-end.ejs'); %>
 <%- include('../_partial/footer.ejs'); %>

--- a/view/hiscores/no_results.ejs
+++ b/view/hiscores/no_results.ejs
@@ -2,6 +2,7 @@
 <%- include('../_components/frame-top.ejs'); %>
 <%- include('../_components/content-start.ejs'); %>
 <%- include('../_components/title-box.ejs', { title: '2004Scape ' + profile.name + ' Hiscores', links: [{ text: 'All Hiscores', href: '/hiscores' }] }); %>
+<%- include('./partials/profile.ejs', { profile, profiles }) %>
 
 <table bgcolor="black" cellpadding="4" border="0">
     <tbody>

--- a/view/hiscores/partials/profile.ejs
+++ b/view/hiscores/partials/profile.ejs
@@ -1,0 +1,33 @@
+<center>
+    <form id="profile-select-form" method="GET">
+        <select name="profile" id="profile" style="background-color: #B1977E;">
+            <% for (const p of profiles) { %>
+                <option value="<%= p.id %>" <%=profile && profile.id===p.id ? 'selected' : '' %>>
+                    <%= p.name %>
+                </option>
+            <% } %>
+        </select>
+    </form>
+</center>
+
+<script>
+    const form = document.getElementById('profile-select-form');
+    form.action = window.location.pathname; // Set the form action to the current URL
+
+    document.getElementById('profile').addEventListener('change', function () {
+        const params = new URLSearchParams(window.location.search);
+
+        // Preserve existing URL parameters
+        for (const [key, value] of params.entries()) {
+            if (key !== 'profile') {
+                const hiddenInput = document.createElement('input');
+                hiddenInput.type = 'hidden';
+                hiddenInput.name = key;
+                hiddenInput.value = value;
+                form.appendChild(hiddenInput);
+            }
+        }
+
+        form.submit();
+    });
+</script>

--- a/view/hiscores/partials/search.ejs
+++ b/view/hiscores/partials/search.ejs
@@ -8,7 +8,7 @@
                     <td class=b bgcolor=#474747 background=/img/stoneback.gif>
                         <center>
                             <form action="/hiscores"><b>Search by rank</b><br>
-                                <input type=number maxlength=12 size=12 name=rank value=""><br>
+                                <input type=number maxlength=12 size=12 name=rank value="<%= typeof rank !== 'undefined' ? rank : '' %>"><br>
                                 <% if (typeof category !== 'undefined') { %>
                                     <input type="hidden" name="category" value="<%= category.id %>">
                                 <% } %>
@@ -29,7 +29,7 @@
                         <center>
                             <form action="/hiscores">
                                 <b>Search by name</b><br>
-                                <input type=text maxlength=12 size=12 name=username value=""><br>
+                                <input type=text maxlength=12 size=12 name=username value="<%= typeof username !== 'undefined' ? username : '' %>"><br>
                                 <% if (typeof category !== 'undefined') { %>
                                     <input type="hidden" name="category" value="<%= category.id %>">
                                 <% } %>

--- a/view/hiscores/partials/search.ejs
+++ b/view/hiscores/partials/search.ejs
@@ -1,0 +1,44 @@
+<br>
+
+<table>
+    <tr>
+        <td>
+            <table width=200 bgcolor=black cellpadding=4>
+                <tr>
+                    <td class=b bgcolor=#474747 background=/img/stoneback.gif>
+                        <center>
+                            <form action="/hiscores"><b>Search by rank</b><br>
+                                <input type=number maxlength=12 size=12 name=rank value=""><br>
+                                <% if (typeof category !== 'undefined') { %>
+                                    <input type="hidden" name="category" value="<%= category.id %>">
+                                <% } %>
+                                <input type=submit value='Search' style="margin-top: 4px">
+                            </form>
+                        </center>
+                    </td>
+                </tr>
+            </table>
+        </td>
+
+        <td>&nbsp&nbsp&nbsp</td>
+
+        <td>
+            <table width=200 bgcolor=black cellpadding=4>
+                <tr>
+                    <td class=b bgcolor=#474747 background=/img/stoneback.gif>
+                        <center>
+                            <form action="/hiscores">
+                                <b>Search by name</b><br>
+                                <input type=text maxlength=12 size=12 name=username value=""><br>
+                                <% if (typeof category !== 'undefined') { %>
+                                    <input type="hidden" name="category" value="<%= category.id %>">
+                                <% } %>
+                                <input type=submit value='Search' style="margin-top: 4px">
+                            </form>
+                        </center>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>

--- a/view/hiscores/player.ejs
+++ b/view/hiscores/player.ejs
@@ -1,7 +1,7 @@
 <%- include('../_partial/header.ejs', { title: 'Hiscores' }); %>
 <%- include('../_components/frame-top.ejs'); %>
 <%- include('../_components/content-start.ejs'); %>
-<%- include('../_components/title-box.ejs', { title: '2004Scape ' + profile.name + ' Hiscores' }); %>
+<%- include('../_components/title-box.ejs', { title: '2004Scape ' + profile.name + ' Hiscores', links: [{ text: 'All Hiscores', href: '/hiscores' }] }); %>
 
 <table bgcolor="black" cellpadding="4" border="0">
     <tbody>

--- a/view/hiscores/player.ejs
+++ b/view/hiscores/player.ejs
@@ -2,6 +2,7 @@
 <%- include('../_components/frame-top.ejs'); %>
 <%- include('../_components/content-start.ejs'); %>
 <%- include('../_components/title-box.ejs', { title: '2004Scape ' + profile.name + ' Hiscores', links: [{ text: 'All Hiscores', href: '/hiscores' }] }); %>
+<%- include('./partials/profile.ejs', { profile, profiles }) %>
 
 <table bgcolor="black" cellpadding="4" border="0">
     <tbody>

--- a/view/hiscores/player.ejs
+++ b/view/hiscores/player.ejs
@@ -46,5 +46,6 @@
     </tbody>
 </table>
 
+<%- include('./partials/search.ejs') %>
 <%- include('../_components/content-end.ejs'); %>
 <%- include('../_partial/footer.ejs'); %>


### PR DESCRIPTION
- Updated username searching to era accurate (stays on index and highlights rank)
- Added profile selection so you can view hiscores for different versions
- Re-added title links to hiscores player view. I think this was accidentally removed when profiles were implemented
- Simplify index page orderBy query to remove the necessity for two separate orderBy statements