### PR TITLE
Force browser to render in light mode

### DIFF
--- a/view/_partial/header.ejs
+++ b/view/_partial/header.ejs
@@ -2,6 +2,7 @@
     <head>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=0.7, shrink-to-fit=no">
+        <meta name="color-scheme" content="light only">
         <% if (typeof title !== 'undefined') { %>
             <title><%= title %> | 2004Scape</title>
         <% } else { %>

--- a/view/client.ejs
+++ b/view/client.ejs
@@ -3,6 +3,7 @@
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=0.6, shrink-to-fit=no">
+    <meta name="color-scheme" content="light only">
     <title>2004Scape Game</title>
 
     <style>


### PR DESCRIPTION
**Before**

![image](https://github.com/user-attachments/assets/184c8236-50f6-4fd5-a615-6e4f43c9088a)

**After**

![image](https://github.com/user-attachments/assets/5b6a123c-2b2b-4478-93be-15883e58d964)

Docs on the header - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color

If you want to test yourself, use Chrome and set the **Auto Dark Mode for Web Contents** flag as enabled in chrome://flags/