### PR TITLE
feat: Added starting point for basic web-based moderation tools.

### DIFF
--- a/public/css/modals.css
+++ b/public/css/modals.css
@@ -1,0 +1,34 @@
+.focused-dialog::backdrop {
+  background-color: rgba(0, 0, 0, .75);
+}
+
+#modal-ban-player {
+  padding: 0;
+  background-color: ivory;
+}
+#modal-ban-player > div {
+  background-color: brown; /* "brown" */
+}
+#modal-ban-player > div > h2 {
+  font-size: 1.25rem;
+  color: white;
+  margin: 0;
+  padding: 0.5rem;
+}
+#modal-ban-player > form {
+  padding: 1rem;
+  margin: 0;
+}
+#modal-ban-player > form > h3 {
+  margin-top: 0;
+}
+#modal-ban-player .modal-ban-player-time-container > br {
+  margin-bottom: 1rem;
+}
+#modal-ban-player > form > div:not(:last-child) {
+  margin-bottom: 1rem;
+}
+#modal-ban-player #modal-cancel-ban-btn,
+#modal-ban-player #modal-ban-player-btn {
+  cursor: pointer;
+}

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -1,0 +1,12 @@
+.row {
+  display: flex;
+  justify-content: space-around;
+}
+
+.hidden {
+  display: none;
+}
+
+.pointer-cursor {
+  cursor: pointer;
+}

--- a/src/routes/mod/index.ts
+++ b/src/routes/mod/index.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 
-import { db } from '#/db/query.js';
+import { db, toDbDate } from '#/db/query.js';
 import { toDisplayName } from '#/jstring/JString.js';
 import LoggerEventType from '#/util/LoggerEventType.js';
 
@@ -136,5 +136,21 @@ export default async function (app: FastifyInstance) {
             console.error(err);
             res.redirect('/', 302);
         }
+    });
+
+    app.post('/ban/:id', async (req: any, res: any) => {
+        if (!req.session.account || req.session.account.staffmodlevel < 1) {
+            return res.status(401).send();
+        }
+
+        const { id } = req.params;
+        const { banned_until } = req.body;
+
+        await db.updateTable('account')
+            .set({ banned_until: toDbDate(banned_until) })
+            .where('id', '=', id)
+            .execute();
+        
+        return res.status(200).send();
     });
 }

--- a/view/_components/modal-ban-player.ejs
+++ b/view/_components/modal-ban-player.ejs
@@ -1,0 +1,24 @@
+<dialog id="modal-ban-player" class="focused-dialog">
+  <div>
+    <h2>Are You Sure?</h2>
+  </div>
+  <form method="post">
+    <h3 id="modal-ban-player-username">Please select <span style="color:maroon">$USERNAME</span>'s ban length:</h3>
+    <div class="modal-ban-player-time-container">
+      <select id="modal-ban-player-time-select" value="1">
+        <option value="1">1 Day</option>
+        <option value="3">3 Days</option>
+        <option value="7">7 Days</option>
+        <option value="14">14 Days</option>
+        <option value="-1">Custom...</option>
+      </select>
+      <br>
+      <input class="hidden" id="modal-ban-player-time-custom" type="number" placeholder="# of days...">
+    </div>
+    <div class="row">
+      <%- include('stones-button.ejs', { id: 'modal-cancel-ban-btn', text: 'Mercy' }); %>
+      <span style="width:1rem"></span>
+      <%- include('stones-button.ejs', { id: 'modal-ban-player-btn', text: 'Ban', shiny: true }); %>
+    </div>
+  </form>
+</dialog>

--- a/view/_components/stones-button.ejs
+++ b/view/_components/stones-button.ejs
@@ -1,0 +1,17 @@
+<%
+  const btnId = typeof(id) === "string" ? id : undefined;
+  const btnWidth = typeof(width) === "number" ? width : 100;
+  const btnHeight = typeof(height) === "number" ? height : 45;
+  const isShinyButton = typeof(shiny) === "boolean" ? shiny : false;
+  
+  const cssClass = isShinyButton ? 'b2' : 'b';
+  const bgcolor = isShinyButton ? '#570700' : '#474747';
+  const bg = isShinyButton ? '/img/title/shinystonered.jpg' : '/img/stoneback.gif';
+%>
+<table width=<%- btnWidth %> height=<%- btnHeight %> bgcolor="black" cellpadding=2>
+  <tr>
+    <td class="pointer-cursor" <%- btnId ? `id=${btnId} ` : '' %>class=<%- cssClass %> bgcolor=<%- bgcolor %> background=<%- bg %>>
+      <center><%- text %></center>
+    </td>
+  </tr>
+</table>

--- a/view/_partial/header.ejs
+++ b/view/_partial/header.ejs
@@ -34,6 +34,11 @@
             A.pink:hover {text-decoration:underline}
             .whitelink { color: white; text-decoration: none }
         </style>
+
+        <link rel="stylesheet" type="text/css" href="/css/site.css">
+        <% if (typeof modals !== 'undefined') { %>
+            <link rel="stylesheet" type="text/css" href="/css/modals.css">
+        <% } %>
     </head>
 </html>
 <body bgcolor=black text="white" link=#90c040 alink=#90c040 vlink=#90c040 topmargin=0 leftmargin=0>

--- a/view/_scripts/mod/overview.ejs
+++ b/view/_scripts/mod/overview.ejs
@@ -1,0 +1,75 @@
+<script>
+  const banButton = document.getElementById('ban-btn'),
+        muteButton = document.getElementById('mute-btn'),
+        changeUsernameButton = document.getElementById('name-change-btn');
+
+  const banModal = document.getElementById('modal-ban-player');
+
+  const banModalUsername = document.querySelector('#modal-ban-player-username > span'),
+        banModalTimePeriodSelect = document.getElementById('modal-ban-player-time-select'),
+        banModalCustomTimePeriod = document.getElementById('modal-ban-player-time-custom');
+  const banModalBanButton = document.getElementById('modal-ban-player-btn'),
+        banModalMercyButton = document.getElementById('modal-cancel-ban-btn');
+
+  banModalUsername.textContent = accountUsername;
+
+  async function banUser() {
+    if (banModalTimePeriodSelect.value === -1) {
+      if (banModalCustomTimePeriod.value == "" || banModalCustomTimePeriod.value == null) {
+        alert('Please enter amount of days for custom ban time length');
+        return;
+      }
+    }
+
+    let numberOfDays = banModalTimePeriodSelect.value == -1 ? banModalCustomTimePeriod.value : banModalTimePeriodSelect.value;
+    let banDate = new Date();
+    console.log(`Adding ${numberOfDays} to ${banDate.toISOString()}`);
+    banDate.setUTCDate(banDate.getUTCDate() + numberOfDays);
+    console.log(`Added ${numberOfDays} (${banDate.toISOString()})`);
+
+    if (confirm(`Are you sure you want to ban ${accountUsername} for ${numberOfDays} day(s)?`)) {
+      fetch(`/mod/ban/${accountUserId}`, {
+        method: 'POST',
+        body: JSON.stringify({
+          banned_until: banDate.toISOString()
+        }),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }).then(res => {
+        if (res.status == 200) {
+          banModal.close();
+          alert(`Successfully banned ${accountUsername} for ${numberOfDays} day(s).`);
+          window.location.reload();
+        } else {
+          alert('Something went wrong. Please signout and back in, then try again.');
+        }
+      });
+    }
+  }
+
+  // TEMPORARY
+  function nyi() {
+    alert('Not yet implemented! Please try again on another date.');
+  }
+  muteButton.addEventListener('click', nyi);
+  changeUsernameButton.addEventListener('click', nyi);
+
+  banButton.addEventListener('click', (event) => {
+    banModal.showModal();
+  });
+  banModalMercyButton.addEventListener('click', (event) => {
+    banModal.close();
+  });
+  banModalBanButton.addEventListener('click', banUser);
+
+  banModalTimePeriodSelect.addEventListener('change', (event) => {
+    const newValue = event.target.value;
+    if (newValue == -1) {
+      banModalCustomTimePeriod.classList.remove('hidden');
+    } else {
+      banModalCustomTimePeriod.classList.add('hidden');
+    }
+  });
+  
+</script>

--- a/view/mod/overview.ejs
+++ b/view/mod/overview.ejs
@@ -1,9 +1,12 @@
-<%- include('../_partial/header.ejs', { title: 'Mod Overview' }); %>
+<%- include('../_partial/header.ejs', { title: 'Mod Overview', modals: true }); %>
 <%- include('../_components/frame-top.ejs'); %>
 <%- include('../_components/content-start.ejs'); %>
 <%- include('../_components/title-box.ejs', { title: account.username + "'s Mod Overview" }); %>
 
 <%- include('../_components/content-body-start.ejs'); %>
+
+<%- include('../_components/modal-ban-player.ejs', { username: account.username }); %>
+
 <% if (account.banned_until) { %>
 Banned until: <strong><%= account.banned_until.toISOString().replace("T"," ").substring(0, 19); %></strong><br>
 <% } %>
@@ -11,6 +14,12 @@ Banned until: <strong><%= account.banned_until.toISOString().replace("T"," ").su
 <% if (account.muted_until) { %>
 Muted until: <strong><%= account.muted_until.toISOString().replace("T"," ").substring(0, 19); %></strong>
 <% } %>
+
+<div style="display: flex; justify-content: space-around;">
+  <%- include('../_components/stones-button.ejs', { id: 'ban-btn', text: 'Ban', shiny: true }) %>
+  <%- include('../_components/stones-button.ejs', { id: 'name-change-btn', text: 'Change<br>Name' }); %>
+  <%- include('../_components/stones-button.ejs', { id: 'mute-btn', text: 'Mute' }) %>
+</div>
 
 <h3>Sessions</h3>
 
@@ -111,3 +120,9 @@ Muted until: <strong><%= account.muted_until.toISOString().replace("T"," ").subs
 
 <%- include('../_components/content-end.ejs'); %>
 <%- include('../_partial/footer.ejs'); %>
+
+<script>
+  const accountUsername = "<%- account.username %>";
+  const accountUserId = <%- account.id %>;
+</script>
+<%- include('../_scripts/mod/overview.ejs'); %>


### PR DESCRIPTION
Added new web-based moderation actions to perform for authorized users. Currently, only the ban button is functioning, but the mute and change username buttons are there to ensure the layout is consistent.

These buttons are available on the moderation overview page for a user, and soon will be available on the report list page.

![408955021-1e768852-3a93-42e7-8ff4-6e5c129ae243](https://github.com/user-attachments/assets/8e4bbfd8-24f7-4cd9-a6c9-36ec0bd8eae6)

![408955350-728a664f-bec8-4b7e-a465-ac50a11b64b0](https://github.com/user-attachments/assets/16039c8d-1381-4add-9cf5-262247d72570)

![408955388-f32347e2-ab0a-486a-8be4-a353dec1ab5c](https://github.com/user-attachments/assets/77e17708-f5ce-4cde-9a06-bf787c84236d)
